### PR TITLE
Add 'EmptyStringTest.java' which shows problem with empty strings

### DIFF
--- a/src/test/java/com/moandjiezana/toml/EmptyStringTest.java
+++ b/src/test/java/com/moandjiezana/toml/EmptyStringTest.java
@@ -1,0 +1,15 @@
+package com.moandjiezana.toml;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import java.io.File;
+
+public class EmptyStringTest {
+    @Test
+    public void should_parse_multiple_sections() {
+        Toml toml = new Toml().parse("str1 = \"\"\nstr2 = \"Hello, world!\"");
+        assertEquals("", toml.getString("str1"));
+        assertEquals("Hello, world!", toml.getString("str2"));
+    }
+}


### PR DESCRIPTION
I think there is a problem with empty strings, the following test fails, which, I believe, it should not.

Btw: Thank you for the only working Toml parser for java out of the 4 that I tried!
