### PR TITLE
Removed unnecessary Class parameter from getList()

### DIFF
--- a/src/main/java/com/moandjiezana/toml/Toml.java
+++ b/src/main/java/com/moandjiezana/toml/Toml.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonElement;
  *
  * <p>All getters can fall back to default values if they have been provided.
  * Getters for simple values (String, Date, etc.) will return null if no matching key exists.
- * {@link #getList(String, Class)}, {@link #getTable(String)} and {@link #getTables(String)} return empty values if there is no matching key.</p>
+ * {@link #getList(String)}, {@link #getTable(String)} and {@link #getTables(String)} return empty values if there is no matching key.</p>
  *
  * <p>Example usage:</p>
  * <pre><code>
@@ -144,7 +144,7 @@ public class Toml {
   }
 
   @SuppressWarnings("unchecked")
-  public <T> List<T> getList(String key, Class<T> itemClass) {
+  public <T> List<T> getList(String key) {
     List<T> list = (List<T>) get(key);
 
     if (list == null) {

--- a/src/test/java/com/moandjiezana/toml/ArrayTest.java
+++ b/src/test/java/com/moandjiezana/toml/ArrayTest.java
@@ -19,14 +19,14 @@ public class ArrayTest {
   public void should_get_array() throws Exception {
     Toml toml = new Toml().parse("list = [\"a\", \"b\", \"c\"]");
 
-    assertEquals(asList("a", "b", "c"), toml.getList("list", String.class));
+    assertEquals(asList("a", "b", "c"), toml.<String>getList("list"));
   }
 
   @Test
   public void should_allow_multiline_array() throws Exception {
     Toml toml = new Toml().parse(file("should_allow_multiline_array"));
 
-    assertEquals(asList("a", "b", "c"), toml.getList("a", String.class));
+    assertEquals(asList("a", "b", "c"), toml.<String>getList("a"));
   }
 
   @Test
@@ -34,7 +34,7 @@ public class ArrayTest {
   public void should_get_nested_arrays() throws Exception {
     Toml clients = new Toml().parse("data = [ [\"gamma\", \"delta\"], [1, 2]] # just an update to make sure parsers support it");
 
-    assertEquals(asList(asList("gamma", "delta"), asList(1L, 2L)), clients.getList("data", String.class));
+    assertEquals(asList(asList("gamma", "delta"), asList(1L, 2L)), clients.<String>getList("data"));
   }
 
   @Test
@@ -42,7 +42,7 @@ public class ArrayTest {
   public void should_get_nested_arrays_with_no_space_between_outer_and_inner_array() throws Exception {
     Toml clients = new Toml().parse("data = [[\"gamma\", \"delta\"], [1, 2]] # just an update to make sure parsers support it");
 
-    assertEquals(asList(asList("gamma", "delta"), asList(1L, 2L)), clients.getList("data", String.class));
+    assertEquals(asList(asList("gamma", "delta"), asList(1L, 2L)), clients.<String>getList("data"));
   }
 
   @Test
@@ -56,21 +56,21 @@ public class ArrayTest {
   public void should_ignore_comma_at_end_of_array() throws Exception {
     Toml toml = new Toml().parse("key=[1,2,3,]");
 
-    assertEquals(asList(1L, 2L, 3L), toml.getList("key", Long.class));
+    assertEquals(asList(1L, 2L, 3L), toml.<Long>getList("key"));
   }
   
   @Test
   public void should_support_mixed_string_types() throws Exception {
     Toml toml = new Toml().parse("key = [\"a\", 'b', \"\"\"c\"\"\", '''d''']");
     
-    assertThat(toml.getList("key", String.class), contains("a", "b", "c", "d"));
+    assertThat(toml.<String>getList("key"), contains("a", "b", "c", "d"));
   }
   
   @Test
   public void should_support_array_terminator_in_strings() throws Exception {
     Toml toml = new Toml().parse("key = [\"a]\", 'b]', \"\"\"c]\"\"\", '''d]''']");
     
-    assertThat(toml.getList("key", String.class), contains("a]", "b]", "c]", "d]"));
+    assertThat(toml.<String>getList("key"), contains("a]", "b]", "c]", "d]"));
   }
   
   private File file(String file) {

--- a/src/test/java/com/moandjiezana/toml/RealWorldTest.java
+++ b/src/test/java/com/moandjiezana/toml/RealWorldTest.java
@@ -42,7 +42,7 @@ public class RealWorldTest {
     assertEquals("192.168.1.1", database.getString("server"));
     assertEquals(5000L, database.getLong("connection_max").longValue());
     assertTrue(database.getBoolean("enabled"));
-    assertEquals(Arrays.asList(8001L, 8001L, 8002L), database.getList("ports", Long.class));
+    assertEquals(Arrays.asList(8001L, 8001L, 8002L), database.<Long>getList("ports"));
 
     Toml servers = toml.getTable("servers");
     Toml alphaServers = servers.getTable("alpha");
@@ -54,8 +54,8 @@ public class RealWorldTest {
     assertEquals("中国", betaServers.getString("country"));
 
     Toml clients = toml.getTable("clients");
-    assertEquals(asList(asList("gamma", "delta"), asList(1L, 2L)), clients.getList("data", String.class));
-    assertEquals(asList("alpha", "omega"), clients.getList("hosts", String.class));
+    assertEquals(asList(asList("gamma", "delta"), asList(1L, 2L)), clients.<String>getList("data"));
+    assertEquals(asList("alpha", "omega"), clients.<String>getList("hosts"));
   }
 
   @Test
@@ -63,13 +63,13 @@ public class RealWorldTest {
     Toml toml = new Toml().parse(new File(getClass().getResource("hard_example.toml").getFile()));
 
     assertEquals("You'll hate me after this - #", toml.getString("the.test_string"));
-    assertEquals(asList("] ", " # "), toml.getList("the.hard.test_array", String.class));
-    assertEquals(asList("Test #11 ]proved that", "Experiment #9 was a success"), toml.getList("the.hard.test_array2", String.class));
+    assertEquals(asList("] ", " # "), toml.<String>getList("the.hard.test_array"));
+    assertEquals(asList("Test #11 ]proved that", "Experiment #9 was a success"), toml.<String>getList("the.hard.test_array2"));
     assertEquals(" Same thing, but with a string #", toml.getString("the.hard.another_test_string"));
     assertEquals(" And when \"'s are in the string, along with # \"", toml.getString("the.hard.harder_test_string"));
     Toml theHardBit = toml.getTable("the.hard.\"bit#\"");
     assertEquals("You don't think some user won't do that?", theHardBit.getString("\"what?\""));
-    assertEquals(asList("]"), theHardBit.getList("multi_line_array", String.class));
+    assertEquals(asList("]"), theHardBit.<String>getList("multi_line_array"));
   }
   
   @SuppressWarnings("unchecked")
@@ -106,12 +106,12 @@ public class RealWorldTest {
     assertEquals(6.626e-34, toml.getDouble("Float.both.key").doubleValue(), 0);
     assertTrue(toml.getBoolean("Booleans.True"));
     assertFalse(toml.getBoolean("Booleans.False"));
-    assertThat(toml.getList("Array.key1", Long.class), contains(1L, 2L, 3L));
-    assertThat(toml.getList("Array.key2", String.class), contains("red", "yellow", "green"));
-    assertEquals(asList(asList(1L, 2L), asList(3L, 4L, 5L)), toml.getList("Array.key3", List.class));
-    assertEquals(asList(asList(1L, 2L), asList("a", "b", "c")), toml.getList("Array.key4", List.class));
-    assertThat(toml.getList("Array.key5", Long.class), contains(1L, 2L, 3L));
-    assertThat(toml.getList("Array.key6", Long.class), contains(1L, 2L));
+    assertThat(toml.<Long>getList("Array.key1"), contains(1L, 2L, 3L));
+    assertThat(toml.<String>getList("Array.key2"), contains("red", "yellow", "green"));
+    assertEquals(asList(asList(1L, 2L), asList(3L, 4L, 5L)), toml.<List>getList("Array.key3"));
+    assertEquals(asList(asList(1L, 2L), asList("a", "b", "c")), toml.<List>getList("Array.key4"));
+    assertThat(toml.<Long>getList("Array.key5"), contains(1L, 2L, 3L));
+    assertThat(toml.<Long>getList("Array.key6"), contains(1L, 2L));
     assertEquals("Hammer", toml.getString("products[0].name"));
     assertEquals(738594937, toml.getLong("products[0].sku").intValue());
     assertNotNull(toml.getTable("products[1]"));

--- a/src/test/java/com/moandjiezana/toml/TomlTest.java
+++ b/src/test/java/com/moandjiezana/toml/TomlTest.java
@@ -71,7 +71,7 @@ public class TomlTest {
   public void should_return_empty_list_if_no_value_for_key() throws Exception {
     Toml toml = new Toml().parse("");
 
-    assertTrue(toml.getList("a", String.class).isEmpty());
+    assertTrue(toml.<String>getList("a").isEmpty());
   }
 
   @Test
@@ -158,7 +158,7 @@ public class TomlTest {
     cal.set(Calendar.MILLISECOND, 0);
     cal.setTimeZone(TimeZone.getTimeZone("UTC"));
     assertEquals(cal.getTime(), toml.getDate("d"));
-    assertThat(toml.getList("e", String.class), Matchers.contains("a", "b"));
+    assertThat(toml.<String>getList("e"), Matchers.contains("a", "b"));
     assertTrue(toml.getBoolean("f"));
     assertEquals("abc", toml.getString("g"));
     assertEquals("abc", toml.getString("h"));


### PR DESCRIPTION
Currently the second parameter of getList() is only used to determine the return type.

The same can be achieved with "toml.\<String\>getList("key")"