### PR TITLE
Nested quotes support

### DIFF
--- a/src/main/java/com/moandjiezana/toml/Keys.java
+++ b/src/main/java/com/moandjiezana/toml/Keys.java
@@ -4,6 +4,29 @@ import java.util.ArrayList;
 import java.util.List;
 
 class Keys {
+  static enum Quote {
+    NONE(' '),
+    SINGLE('\''),
+    DOUBLE('"');
+    
+    private final char quote;
+    
+    private Quote(char quote) {
+      this.quote = quote;
+    }
+    static Quote quoteFromChar(char c) {
+      if (c == '\'') {
+        return Quote.SINGLE;
+      } else if (c == '"') {
+        return Quote.DOUBLE;
+      } else {
+        return Quote.NONE;
+      }
+    }
+    char getChar() {
+      return this.quote;
+    }
+  }
   
   static class Key {
     final String name;
@@ -24,7 +47,7 @@ class Keys {
   static Keys.Key[] split(String key) {
     List<Key> splitKey = new ArrayList<Key>();
     StringBuilder current = new StringBuilder();
-    boolean quoted = false;
+    Quote quote = Quote.NONE;
     boolean indexable = true;
     boolean inIndex = false;
     int index = -1;
@@ -43,10 +66,14 @@ class Keys {
         continue;
       }
       if (isQuote(c) && (i == 0 || key.charAt(i - 1) != '\\')) {
-        quoted = !quoted;
+        if (quote != Quote.NONE && quote.getChar() == c) {
+          quote = Quote.NONE;
+        } else {
+          quote = Quote.quoteFromChar(c);
+        }
         indexable = false;
       }
-      if (c != '.' || quoted) {
+      if (c != '.' || quote != Quote.NONE) {
         current.insert(0, c);
       } else {
         splitKey.add(0, new Key(current.toString(), index, !splitKey.isEmpty() ? splitKey.get(0) : null));

--- a/src/test/java/com/moandjiezana/toml/TableTest.java
+++ b/src/test/java/com/moandjiezana/toml/TableTest.java
@@ -131,4 +131,37 @@ public class TableTest {
   public void should_fail_when_illegal_characters_after_table() throws Exception {
     new Toml().read("[error]   if you didn't catch this, your parser is broken");
   }
+  @Test
+  public void should_accept_table_name_part_with_basic_string_nested_single_quotes() {
+    Toml toml = new Toml().read("[target.\"cfg(os='android')\".dependencies]\nb = 'b'");
+
+    assertEquals("b", toml.getString("target.\"cfg(os='android')\".dependencies.b"));
+  }
+
+  @Test
+  public void should_accept_table_name_part_with_whitespace_and_basic_string_nested_single_quotes() {
+    Toml toml = new Toml().read("[ target . \"cfg (os = 'android')\" . dependencies ]\nb = 'b'");
+
+    assertEquals("b", toml.getString("target.\"cfg (os = 'android')\".dependencies.b"));
+  }
+  @Test
+  public void should_accept_table_name_part_with_whitespace_and_basic_string_nested_escaped_quotes() {
+    Toml toml = new Toml().read("[ target . \"cfg (os = \\\"android\\\")\" . dependencies ]\nb = 'b'");
+
+    assertEquals("b", toml.getString("target.\"cfg (os = \\\"android\\\")\".dependencies.b"));
+  }
+
+  @Test
+  public void should_accept_table_name_part_with_literal_string_nested_double_quotes() {
+    Toml toml = new Toml().read("[target.'cfg(os=\"android\")'.dependencies]\nb = 'b'");
+
+    assertEquals("b", toml.getString("target.'cfg(os=\"android\")'.dependencies.b"));
+  }
+
+  @Test
+  public void should_accept_table_name_part_with_whitespace_and_literal_string_nested_double_quotes() {
+    Toml toml = new Toml().read("[target . 'cfg(os = \"android\")' . dependencies]\nb = 'b'");
+
+    assertEquals("b", toml.getString("target.'cfg(os=\"android\")'.dependencies.b"));
+  }
 }


### PR DESCRIPTION
Rust heavily uses constructions like `target.'cfg(target_os = "android")'.dependencies` in its TOML configs.