### PR TITLE
Add @TomlIgnore and @TomlComment annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,23 @@
 # toml4j Changelog
 
+## [Unreleased]
+
+### Added
+* @TomlIgnore and @TomlComment annotations for Toml Objects
+
 ## 0.7.3 / 2017-12-13
 
-## Fixed
+### Fixed
 
 * [A table array in comments caused a parse error](https://github.com/mwanji/toml4j/issues/48) (thanks to __[bchenYext](https://github.com/bchenYext)__)
 
 ## 0.7.2 / 2017-08-05
 
-## Updated
+### Updated
 
 * [Update Gson to 2.8.1 and various Maven plugins to latest versions](https://github.com/mwanji/toml4j/pull/45) (thanks to __[DanilaFe](https://github.com/DanilaFe)__)
 
-## Fixed
+### Fixed
 
 * [tomlWriter.write NullPointerException in JDK9](https://github.com/mwanji/toml4j/issues/46) (thanks to __[iwangxiaodong](https://github.com/iwangxiaodong)__)
 * Change build to be able to release a new version entirely from the command line
@@ -23,17 +28,17 @@
 
 ## 0.7.0 / 2016-07-12
 
-## Added
+### Added
 
 * Toml#read(Toml) merges two Toml instances (thanks to __[gustavkarlsson](https://github.com/gustavkarlsson)__)
 
 ## 0.6.0 / 2016-06-14
 
-## Added
+### Added
 
 * Toml#toMap() convenience method (thanks to __[andytill](https://github.com/andytill)__ and __[Gyscos](https://github.com/Gyscos)) 
 
-## Fixed
+### Fixed
 
 * Transient fields are not written to TOML files (thanks to __[lare96](https://github.com/lare96)__)
 * Support positive timezone offset in datetime (thanks to __[aloyse](https://github.com/aloyse)__)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.moandjiezana.toml</groupId>
   <artifactId>toml4j</artifactId>
-  <version>0.7.3-SNAPSHOT</version>
+  <version>0.7.4-SNAPSHOT</version>
   <name>toml4j</name>
   <description>A parser for TOML</description>
   <url>http://moandjiezana.com/toml/toml4j</url>
@@ -79,7 +79,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.9</version>
+        <version>0.8.5</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/src/main/java/com/moandjiezana/toml/CommentUtil.java
+++ b/src/main/java/com/moandjiezana/toml/CommentUtil.java
@@ -1,0 +1,25 @@
+package com.moandjiezana.toml;
+
+public class CommentUtil {
+  public static void addComments(final String[] comments, final WriterContext context) {
+    addComments(comments, context, true);
+  }
+
+  public static void addComments(final String[] comments, final WriterContext context, boolean ident) {
+    if (comments == null) return;
+    for (final String comment : comments) {
+      if (comment == null) continue;
+      if (comment.contains("\n")) {
+        final String[] split = comment.split("\n");
+        for (final String c : split) {
+          if (c == null) continue;
+          if (ident) context.indent();
+          context.write("# " + c + "\n");
+        }
+      } else {
+        if (ident) context.indent();
+        context.write("# " + comment + "\n");
+      }
+    }
+  }
+}

--- a/src/main/java/com/moandjiezana/toml/MapValueWriter.java
+++ b/src/main/java/com/moandjiezana/toml/MapValueWriter.java
@@ -1,71 +1,20 @@
 package com.moandjiezana.toml;
 
-import static com.moandjiezana.toml.PrimitiveArrayValueWriter.PRIMITIVE_ARRAY_VALUE_WRITER;
-import static com.moandjiezana.toml.TableArrayValueWriter.TABLE_ARRAY_VALUE_WRITER;
-import static com.moandjiezana.toml.ValueWriters.WRITERS;
-
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.moandjiezana.toml.PrimitiveArrayValueWriter.PRIMITIVE_ARRAY_VALUE_WRITER;
+import static com.moandjiezana.toml.TableArrayValueWriter.TABLE_ARRAY_VALUE_WRITER;
+import static com.moandjiezana.toml.ValueWriters.WRITERS;
 
 class MapValueWriter implements ValueWriter {
   static final ValueWriter MAP_VALUE_WRITER = new MapValueWriter();
 
   private static final Pattern REQUIRED_QUOTING_PATTERN = Pattern.compile("^.*[^A-Za-z\\d_-].*$");
 
-  @Override
-  public boolean canWrite(Object value) {
-    return value instanceof Map;
-  }
-
-  @Override
-  public void write(Object value, WriterContext context) {
-    Map<?, ?> from = (Map<?, ?>) value;
-
-    if (hasPrimitiveValues(from, context)) {
-      context.writeKey();
-    }
-
-    // Render primitive types and arrays of primitive first so they are
-    // grouped under the same table (if there is one)
-    for (Map.Entry<?, ?> entry : from.entrySet()) {
-      Object key = entry.getKey();
-      Object fromValue = entry.getValue();
-      if (fromValue == null) {
-        continue;
-      }
-
-      ValueWriter valueWriter = WRITERS.findWriterFor(fromValue);
-      if (valueWriter.isPrimitiveType()) {
-        context.indent();
-        context.write(quoteKey(key)).write(" = ");
-        valueWriter.write(fromValue, context);
-        context.write('\n');
-      } else if (valueWriter == PRIMITIVE_ARRAY_VALUE_WRITER) {
-        context.setArrayKey(key.toString());
-        context.write(quoteKey(key)).write(" = ");
-        valueWriter.write(fromValue, context);
-        context.write('\n');
-      }
-    }
-
-    // Now render (sub)tables and arrays of tables
-    for (Object key : from.keySet()) {
-      Object fromValue = from.get(key);
-      if (fromValue == null) {
-        continue;
-      }
-
-      ValueWriter valueWriter = WRITERS.findWriterFor(fromValue);
-      if (valueWriter == this || valueWriter == ObjectValueWriter.OBJECT_VALUE_WRITER || valueWriter == TABLE_ARRAY_VALUE_WRITER) {
-        valueWriter.write(fromValue, context.pushTable(quoteKey(key)));
-      }
-    }
-  }
-
-  @Override
-  public boolean isPrimitiveType() {
-    return false;
+  private MapValueWriter() {
   }
 
   private static String quoteKey(Object key) {
@@ -94,5 +43,89 @@ class MapValueWriter implements ValueWriter {
     return false;
   }
 
-  private MapValueWriter() {}
+  @Override
+  public boolean canWrite(Object value) {
+    return value instanceof Map;
+  }
+
+  @Override
+  public void write(Object value, WriterContext context) {
+    write(value, context, null);
+  }
+
+  public void write(Object value, WriterContext context, ArrayList<String[]> comments) {
+    Map<?, ?> from = (Map<?, ?>) value;
+
+    if (hasPrimitiveValues(from, context)) {
+      context.writeKey();
+    }
+
+    int comment = 0;
+    // Render primitive types and arrays of primitive first so they are
+    // grouped under the same table (if there is one)
+    for (Map.Entry<?, ?> entry : from.entrySet()) {
+      Object key = entry.getKey();
+      Object fromValue = entry.getValue();
+      if (fromValue == null) {
+        continue;
+      }
+      final boolean hasComment = (comments != null) && !comments.isEmpty() && comments.get(comment) != null;
+      ValueWriter valueWriter = WRITERS.findWriterFor(fromValue);
+      if (hasComment) {
+        if ((valueWriter == MAP_VALUE_WRITER || valueWriter == ObjectValueWriter.OBJECT_VALUE_WRITER))
+          context.write("\n");
+        addComments(comments.get(comment), context);
+      }
+      if (valueWriter.isPrimitiveType()) {
+        context.indent();
+        context.write(quoteKey(key)).write(" = ");
+        valueWriter.write(fromValue, context);
+        context.write('\n');
+      } else if (valueWriter == PRIMITIVE_ARRAY_VALUE_WRITER) {
+        context.setArrayKey(key.toString());
+        context.write(quoteKey(key)).write(" = ");
+        valueWriter.write(fromValue, context);
+        context.write('\n');
+      }
+      comment++;
+    }
+
+    // Now render (sub)tables and arrays of tables
+    for (Object key : from.keySet()) {
+      Object fromValue = from.get(key);
+      if (fromValue == null) {
+        continue;
+      }
+
+      ValueWriter valueWriter = WRITERS.findWriterFor(fromValue);
+      if (valueWriter == this || valueWriter == ObjectValueWriter.OBJECT_VALUE_WRITER || valueWriter == TABLE_ARRAY_VALUE_WRITER) {
+        valueWriter.write(fromValue, context.pushTable(quoteKey(key)));
+      }
+    }
+  }
+
+  private void addComments(final String[] comments, WriterContext context) {
+    if (comments == null) return;
+    for (String comment : comments) {
+      if (comment == null) continue;
+      if (comment.contains("\n")) {
+        final String[] split = comment.split("\n");
+        for (String s : split) {
+          if (s == null) continue;
+          context.indent();
+          context.write("# " + s + "\n");
+        }
+      } else {
+        context.indent();
+        context.write("# " + comment + "\n");
+      }
+    }
+
+  }
+
+  @Override
+  public boolean isPrimitiveType() {
+    return false;
+  }
+
 }

--- a/src/main/java/com/moandjiezana/toml/TomlComment.java
+++ b/src/main/java/com/moandjiezana/toml/TomlComment.java
@@ -1,0 +1,18 @@
+package com.moandjiezana.toml;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Define comments for TOML objects
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface TomlComment {
+  /**
+   * Comment(s) to add. Supports multilined comments with '\n' or by providing multiple Strings
+   */
+  String[] value();
+}

--- a/src/main/java/com/moandjiezana/toml/TomlIgnore.java
+++ b/src/main/java/com/moandjiezana/toml/TomlIgnore.java
@@ -1,0 +1,14 @@
+package com.moandjiezana.toml;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * When added to an field, it will be completely ignored when writing the config
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface TomlIgnore {
+}

--- a/src/main/java/com/moandjiezana/toml/WriterContext.java
+++ b/src/main/java/com/moandjiezana/toml/WriterContext.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.Arrays;
 
+import static com.moandjiezana.toml.CommentUtil.addComments;
+
 class WriterContext {
   private String arrayKey = null;
   private boolean isArrayOfTable = false;
@@ -68,7 +70,7 @@ class WriterContext {
     try {
       output.write(c);
       empty = false;
-      
+
       return this;
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -76,6 +78,10 @@ class WriterContext {
   }
 
   void writeKey() {
+    writeKey(null);
+  }
+
+  void writeKey(String[] comment) {
     if (key.isEmpty()) {
       return;
     }
@@ -83,9 +89,11 @@ class WriterContext {
     if (!empty) {
       write('\n');
     }
-
+    if (comment != null) {
+      write(currentTableIndent);
+      addComments(comment, this, false);
+    }
     write(currentTableIndent);
-
     if (isArrayOfTable) {
       write("[[").write(key).write("]]\n");
     } else {

--- a/src/test/java/com/moandjiezana/toml/ClassWithAnnotationsTest.java
+++ b/src/test/java/com/moandjiezana/toml/ClassWithAnnotationsTest.java
@@ -4,9 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 
 import static org.junit.Assert.*;
 
@@ -36,16 +34,31 @@ public class ClassWithAnnotationsTest {
     assertEquals("[Test]", toml.subclass.logPrefix);
     assertArrayEquals(new String[]{"test", "test2"}, toml.subclass.blacklistedWords);
     assertEquals(Integer.MAX_VALUE / 2, toml.subclass.third.maxLength);
-
-    // Print the whole file content to log
-    final BufferedReader r = new BufferedReader(new FileReader(file));
-    System.out.println("--Beginning of file--");
-    while (true) {
-      final String line = r.readLine();
-      if (line == null) break;
-      System.out.println(line);
-    }
-    System.out.println("--End of file--");
+    assertEquals(57392729L, toml.randimzier.seed);
+    final String expectedOutput = "# This toggles debug features\n" +
+            "enableDebugMode = false\n" +
+            "# Delay between messages\n" +
+            "# Can not be negative\n" +
+            "delay = 12\n" +
+            "\n" +
+            "# Subclass containing more configuration options\n" +
+            "[subclass]\n" +
+            "  # An list of words which should not be visible in log\n" +
+            "blacklistedWords = [   \"test\", \"test2\"   ]\n" +
+            "  # The prefix to be shown when sending log messages\n" +
+            "  # Defaults to \"[Test]\"\n" +
+            "  logPrefix = \"[Test]\"\n" +
+            "\n" +
+            "    # Even more options\n" +
+            "    [subclass.third]\n" +
+            "      # Max length of messages\n" +
+            "      maxLength = 1073741823\n" +
+            "\n" +
+            "# Config for the randomizer\n" +
+            "[randimzier]\n" +
+            "  # The seed of the randomizer\n" +
+            "  seed = 57392729\n";
+    assertEquals(expectedOutput, w.write(toml));
   }
 
   private static class FirstAnnotated {
@@ -57,6 +70,9 @@ public class ClassWithAnnotationsTest {
     private int delay = 12;
     @TomlComment("Subclass containing more configuration options")
     private SecondAnnotated subclass = new SecondAnnotated();
+    @TomlComment("Config for the randomizer")
+    private FourthAnnotated randimzier = new FourthAnnotated();
+
 
     private static class SecondAnnotated {
       @TomlComment("An list of words which should not be visible in log")
@@ -71,5 +87,10 @@ public class ClassWithAnnotationsTest {
         private int maxLength = Integer.MAX_VALUE / 2;
       }
     }
+  }
+
+  private static class FourthAnnotated {
+    @TomlComment("The seed of the randomizer")
+    private long seed = 57392729L;
   }
 }

--- a/src/test/java/com/moandjiezana/toml/ClassWithAnnotationsTest.java
+++ b/src/test/java/com/moandjiezana/toml/ClassWithAnnotationsTest.java
@@ -1,0 +1,75 @@
+package com.moandjiezana.toml;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+
+import static org.junit.Assert.*;
+
+public class ClassWithAnnotationsTest {
+  @Rule
+  public TemporaryFolder testDirectory = new TemporaryFolder();
+
+  @Test
+  public void should_support_SerializedName() throws Exception {
+    File file = testDirectory.newFile();
+
+    //Save config
+    final FirstAnnotated newInst = new FirstAnnotated();
+    newInst.ignoredField = "I should not be visible in the file";
+    final TomlWriter w = new TomlWriter.Builder()
+            .indentValuesBy(2)
+            .indentTablesBy(4)
+            .padArrayDelimitersBy(3)
+            .build();
+    w.write(newInst, file);
+
+    //Load it back up
+    final FirstAnnotated toml = new Toml().read(file).to(FirstAnnotated.class);
+    assertNull(toml.ignoredField);
+    assertFalse(toml.enableDebugMode);
+    assertEquals(12, toml.delay);
+    assertEquals("[Test]", toml.subclass.logPrefix);
+    assertArrayEquals(new String[]{"test", "test2"}, toml.subclass.blacklistedWords);
+    assertEquals(Integer.MAX_VALUE / 2, toml.subclass.third.maxLength);
+
+    // Print the whole file content to log
+    final BufferedReader r = new BufferedReader(new FileReader(file));
+    System.out.println("--Beginning of file--");
+    while (true) {
+      final String line = r.readLine();
+      if (line == null) break;
+      System.out.println(line);
+    }
+    System.out.println("--End of file--");
+  }
+
+  private static class FirstAnnotated {
+    @TomlIgnore
+    private String ignoredField;
+    @TomlComment("This toggles debug features")
+    private boolean enableDebugMode = false;
+    @TomlComment({"Delay between messages", "Can not be negative"})
+    private int delay = 12;
+    @TomlComment("Subclass containing more configuration options")
+    private SecondAnnotated subclass = new SecondAnnotated();
+
+    private static class SecondAnnotated {
+      @TomlComment("An list of words which should not be visible in log")
+      private String[] blacklistedWords = new String[]{"test", "test2"};
+      @TomlComment("The prefix to be shown when sending log messages\nDefaults to \"[Test]\"")
+      private String logPrefix = "[Test]";
+      @TomlComment("Even more options")
+      private ThirdAnnotated third = new ThirdAnnotated();
+
+      private static class ThirdAnnotated {
+        @TomlComment("Max length of messages")
+        private int maxLength = Integer.MAX_VALUE / 2;
+      }
+    }
+  }
+}


### PR DESCRIPTION
I added two annotations to this library:
- @TomlIgnore <br>
Fields with this annotation will not get written to the toml file.

- @TomlComment <br>
When adding this annotation to an field, the value of this annotation will get written as comment above the toml entry

Example:
```java
public class SomeConfig {
   @TomlIgnore
   public int secretInteger = 42;

   @TomlComment("This is an comment")
   public String key1 = "value1";

   @TomlComment({"This is an", "multilined comment"})
   public String key2 = "value2";

   @TomlComment("This is also\nan multilined comment")
   public String key3 = "value3";
}
```
Written to toml file using `TomlWriter`:
```toml
# This is an comment
key1 = "value1"
# This is an
# multilied comment
key2 = "value2"
# This is also
# an multilined comment
key3 = "value3"
```


Need another use example? I already used it [here](https://github.com/ErdbeerbaerLP/CustomServerMessages/blob/1.15/src/main/java/de/erdbeerbaerlp/customServerMessages/CustomMessagesConfig.java) to create an configuration file