### PR TITLE
Added gradle to the dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Add the following dependency to your POM (or equivalent for other dependency man
 </dependency>
 ```
 
+If you use gradle, you can use the following code :
+```gradle
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  ...
+  implementation 'com.moandjiezana.toml:toml4j:0.7.2'
+}
+```
+
 Requires Java 1.6 or above.
 
 ## Quick start


### PR DESCRIPTION
Nowadays, Gradle is a well-known tool and is used by dozens of developers, so I think that it's important for a library to have the Gradle integration code into its README file. 