### PR TITLE
Make compatible with modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
-  - openjdk6
+  - oraclejdk9
+  - openjdk9
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </developer>
   </developers>
   <inceptionYear>2013</inceptionYear>
-  
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -71,10 +71,35 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
+        <executions>
+          <execution>
+            <id>compile-java-6</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <source>1.6</source>
+              <target>1.6</target>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-java-9</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>9</release>
+              <compileSourceRoots>
+                <compileSourceRoot>
+                  ${project.basedir}/src/main/java9
+                </compileSourceRoot>
+              </compileSourceRoots>
+              <outputDirectory>
+                ${project.build.outputDirectory}/META-INF/versions/9
+              </outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -1,0 +1,3 @@
+module com.moandjiezana.toml {
+    exports com.moandjiezana.toml;
+}


### PR DESCRIPTION
This PR
* Adds a module-info.java so that this can be used in modular projects that want to use jlink via the Multi Release Jar mechanism
* Moves tests on travis CI to use java 9 because I couldn't think of another way.

My motivation here is kinda simply to parse a toml file in my modular app.