### PR TITLE
Unicode escape sequences are not reqular

### DIFF
--- a/src/test/java/com/moandjiezana/toml/UnicodeTest.java
+++ b/src/test/java/com/moandjiezana/toml/UnicodeTest.java
@@ -7,16 +7,21 @@ import org.junit.Test;
 public class UnicodeTest {
 
   @Test
-  public void should_support_short_escape_form() throws Exception {
-    Toml toml = new Toml().read("key = \"Jos\u00E9\\nLocation\tSF\"");
-    
+  public void should_support_short_escape_form() {
+    Toml toml = new Toml().read("key = \"Jos\\u00E9\\nLocation\tSF\"");
     assertEquals("José\nLocation\tSF", toml.getString("key"));
   }
 
   @Test
-  public void should_support_unicode_literal() throws Exception {
+  public void should_support_unicode_literal() {
     Toml toml = new Toml().read("key = \"José LöcÄtion SF\"");
-    
+
     assertEquals("José LöcÄtion SF", toml.getString("key"));
+  }
+
+  @Test
+  public void should_support_escaped_backslashes() {
+    Toml toml = new Toml().read("key = \"C:\\\\Users\"");
+    assertEquals("C:\\Users", toml.getString("key"));
   }
 }


### PR DESCRIPTION
The project used a regular expression to parse unicode escapes, but this falls short when you have a windows path in a value:

``` toml
key = "c:\\\\Users"
````

I rewrote the unescaping by hand and it fixes the issues.