### PR TITLE
Added the `TomlKey` annotation solves the problem where Java variable names cannot contain `-` while the configuration file keys include `-`.

### DIFF
--- a/src/main/java/com/moandjiezana/toml/KeyFieldNamingStrategy.java
+++ b/src/main/java/com/moandjiezana/toml/KeyFieldNamingStrategy.java
@@ -1,0 +1,31 @@
+package com.moandjiezana.toml;
+
+import com.google.gson.FieldNamingStrategy;
+
+import java.lang.reflect.Field;
+
+/**
+ * @since 2025/10/9
+ * @author Frish2021
+ * <p>
+ *
+ * Example:
+ * <code>
+ *     class AClass {
+ *         {@code @TomlKey("test-name")}
+ *         String testName;
+ *     }
+ * </code>
+ */
+public enum KeyFieldNamingStrategy implements FieldNamingStrategy {
+    INSTANCE;
+
+    @Override
+    public String translateName(Field field) {
+        if (!field.isAnnotationPresent(TomlKey.class)) {
+            return field.getName();
+        }
+
+        return field.getAnnotation(TomlKey.class).value();
+    }
+}

--- a/src/main/java/com/moandjiezana/toml/Toml.java
+++ b/src/main/java/com/moandjiezana/toml/Toml.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 
 /**
@@ -40,8 +41,8 @@ import com.google.gson.JsonElement;
  *
  */
 public class Toml {
-  
-  private static final Gson DEFAULT_GSON = new Gson();
+
+  private static final Gson DEFAULT_GSON = new GsonBuilder().setFieldNamingStrategy(KeyFieldNamingStrategy.INSTANCE).create();
 
   private Map<String, Object> values = new HashMap<String, Object>();
   private final Toml defaults;

--- a/src/main/java/com/moandjiezana/toml/TomlKey.java
+++ b/src/main/java/com/moandjiezana/toml/TomlKey.java
@@ -1,0 +1,12 @@
+package com.moandjiezana.toml;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TomlKey {
+    String value();
+}

--- a/src/test/java/com/moandjiezana/toml/QuotedKeysTest.java
+++ b/src/test/java/com/moandjiezana/toml/QuotedKeysTest.java
@@ -1,9 +1,7 @@
 package com.moandjiezana.toml;
 
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import java.util.Map;
 
@@ -59,7 +57,15 @@ public class QuotedKeysTest {
     assertNull(quoted.ʎǝʞ);
     assertEquals("value", quoted.map.get("\"ʎǝʞ\""));
   }
-  
+
+  @Test
+  public void should_support_field_name_has_underline() {
+      Key tomlInstance = new Toml().read("test-name=\"Hello World!!\"").to(Key.class);
+
+      assertNotNull(tomlInstance.testName);
+      assertEquals(tomlInstance.testName, "Hello World!!");
+  }
+
   @Test
   public void should_support_table_array_index_with_quoted_key() throws Exception {
     Toml toml = new Toml().read("[[ dog. \" type\" ]] \n  name = \"type0\"  \n  [[dog.\" type\"]]  \n  name = \"type1\"");
@@ -133,5 +139,10 @@ public class QuotedKeysTest {
     String ʎǝʞ;
     
     Map<String, Object> map;
+  }
+
+  private static class Key {
+      @TomlKey("test-name")
+      String testName;
   }
 }


### PR DESCRIPTION
This commit added the `TomlKey` annotation solves the problem where Java variable names cannot contain `-` while the configuration file keys include `-`.

Example:

```java
public class User {
    @TomlKey("test-name")
    String testName;
}
```
